### PR TITLE
[feature] spt 기반 구현 및 VM / lazy-load 개선

### DIFF
--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -7,6 +7,7 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	bool writable;
 };
 
 void vm_file_init (void);

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -48,6 +48,7 @@ struct page {
 
 	/* project3 spt */
 	struct hash_elem he;
+	bool writable;         /* True if writable, false if read-only */
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -87,7 +88,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
-	struct hash *pages;
+	struct hash pages;
 };
 
 #include "threads/thread.h"
@@ -119,5 +120,14 @@ spt_hash_func (const struct hash_elem *hash_e, void *aux);
 static bool
 spt_less_func (const struct hash_elem *a, const struct hash_elem *b, void *aux);
 
+
+struct file_load_aux
+{
+	struct file *file;
+	off_t offset;
+	size_t read_bytes;
+	size_t zero_bytes;
+	// bool writable;
+};
 
 #endif  /* VM_VM_H */

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -140,25 +140,28 @@ page_fault (struct intr_frame *f) {
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
 
-	if (user) {
-		thread_current ()->exit_num = -1;
-		thread_exit ();
-	}
 
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
+	else{
+		/* If the fault is true fault, show info and exit. */
+		printf ("Page fault at %p: %s error %s page in %s context.\n",
+				fault_addr,
+				not_present ? "not present" : "rights violation",
+				write ? "writing" : "reading",
+				user ? "user" : "kernel");
+	}
+	
 #endif
 
 	/* Count page faults. */
 	page_fault_cnt++;
-
-	/* If the fault is true fault, show info and exit. */
-	printf ("Page fault at %p: %s error %s page in %s context.\n",
-			fault_addr,
-			not_present ? "not present" : "rights violation",
-			write ? "writing" : "reading",
-			user ? "user" : "kernel");
+	
+	if (user) {
+		thread_current ()->exit_num = -1;
+		thread_exit ();
+	}
 	kill (f);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -6,6 +6,7 @@
 
 /* project3 spt */
 #include "hash.h"
+#include "threads/mmu.h"
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -40,25 +41,54 @@ static struct frame *vm_get_victim (void);
 static bool vm_do_claim_page (struct page *page);
 static struct frame *vm_evict_frame (void);
 
-/* Create the pending page object with initializer. If you want to create a
- * page, do not create it directly and make it through this function or
- * `vm_alloc_page`. */
+/* 초기화 함수를 사용하여 보류 중인 페이지 객체를 생성합니다. 
+ 페이지를 생성하려면 직접 생성하지 말고 이 함수나 
+ `vm_alloc_page`를 통해 생성하세요. */
 bool
 vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		vm_initializer *init, void *aux) {
-
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
-
-	/* Check wheter the upage is already occupied or not. */
+	/* uppage가 이미 사용 중인지 확인하세요. */
 	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
+		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져온 다음, 
+		uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다. 
+		uninit_new를 호출한 후 필드를 수정해야 합니다. */
 
-		/* TODO: Insert the page into the spt. */
+		// 1. 페이지 생성 - palloc으로 할당 하려 하였으나 remove쪽에서 free하기 때문에 malloc으로 변경
+		struct page *page = malloc(sizeof(struct page));
+		if (page == NULL)
+			goto err;
+		// 2. uninit 페이지로 초기화 - "uninit" 페이지 구조체를 생성
+		uninit_new (page, upage, init, type, aux, NULL);
+		page->writable = writable;  // writable 설정
+
+		// 타입별로 page_initializer 설정
+		switch (type) { 
+			case VM_ANON:
+				page->uninit.page_initializer = anon_initializer;
+				break;
+			case VM_FILE:
+				page->uninit.page_initializer = file_backed_initializer;
+				break;
+			case VM_ANON | VM_MARKER_0:
+				page->uninit.page_initializer = anon_initializer;
+				break;
+			default:
+				free(page);
+				goto err;
+		}
+		// 3. spt에 페이지 삽입
+		if (spt_insert_page(spt, page)){
+			return true;
+		}
+		else{
+			free(page);
+			goto err;
+		}
 	}
+
 err:
 	return false;
 }
@@ -68,17 +98,21 @@ struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
 	// va에 대한 검증 필요하려나
-
-	struct page *p;
-	struct hash_elem *e;
-	p->va = va;
-	e = hash_find(spt->pages, &p->he);
-	page = hash_entry(e, struct page, he);
+	// 초기화되지 않은 페이지의 va를 찾을 때 문제가 될 수도?
+	struct page *p = malloc(sizeof(struct page));
+	p->va = pg_round_down(va);
+	struct hash_elem *e = hash_find(&spt->pages, &p->he);
+	if(e == NULL){
+		free(p);
+		return NULL;
+	}
 	
+	page = hash_entry(e, struct page, he);
+
 	if (page == NULL) {
 		return NULL;
 	}
-
+	free(p);
 	return page;
 }
 
@@ -88,7 +122,7 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 		struct page *page UNUSED) {
 	bool succ = false;
 
-	struct hash_elem *old = hash_insert(spt->pages, &page->he);
+	struct hash_elem *old = hash_insert(&spt->pages, &page->he);
 	if (old == NULL) { 
 		succ = true;
 	}
@@ -110,24 +144,40 @@ vm_get_victim (void) {
 	return victim;
 }
 
-/* Evict one page and return the corresponding frame.
- * Return NULL on error.*/
+/* 한 페이지를 제거하고 해당 프레임을 반환합니다.
+ * 오류 발생 시 NULL을 반환합니다.*/
 static struct frame *
 vm_evict_frame (void) {
 	struct frame *victim UNUSED = vm_get_victim ();
-	/* TODO: swap out the victim and return the evicted frame. */
+	/* TODO: 피해자를 교체하고 퇴출된 프레임을 반환합니다. */
 
 	return NULL;
 }
 
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
+/* palloc() 함수를 사용하여 프레임을 가져옵니다. 
+ * 사용 가능한 페이지가 없으면 해당 페이지를 제거하고 반환합니다. 
+ * 이 함수는 항상 유효한 주소를 반환합니다. 
+ * 즉, 사용자 풀 메모리가 가득 차면 이 함수는 프레임을 제거하여 
+ * 사용 가능한 메모리 공간을 확보합니다.*/
 static struct frame *
 vm_get_frame (void) {
-	struct frame *frame = NULL;
-	/* TODO: Fill this function. */
+	struct frame *frame = malloc(sizeof(struct frame));
+	if (frame == NULL) {
+        PANIC("todo");
+    }
+	// palloc으로 프레임 할당
+	frame->kva = palloc_get_page(PAL_USER);
+	
+	// 메모리가 가득 찼거나 공간 부족 등으로 실패
+	if (frame->kva == NULL) {
+		free(frame);
+		PANIC("todo"); // swap 처리 필요
+		// 1. evict 대상 프레임 선택
+		// 2. 해당 프레임을 참조하는 페이지 테이블 항목 제거
+		// 3. 필요하면 swap 또는 파일로 기록
+	}
+
+	frame->page = NULL;
 
 	ASSERT (frame != NULL);
 	ASSERT (frame->page == NULL);
@@ -139,7 +189,7 @@ static void
 vm_stack_growth (void *addr UNUSED) {
 }
 
-/* Handle the fault on write_protected page */
+/* write_protected 페이지에서 오류를 처리합니다. */
 static bool
 vm_handle_wp (struct page *page UNUSED) {
 }
@@ -148,11 +198,22 @@ vm_handle_wp (struct page *page UNUSED) {
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
+	struct supplemental_page_table *spt = &thread_current ()->spt;
 	struct page *page = NULL;
-	/* TODO: Validate the fault */
-	/* TODO: Your code goes here */
-
+	/* 페이지 유효성 검사 */
+	// TODO : spt_find_page안에서 pg_round_down을 하는 것이 아닌 여기서만 하는 것이 맞겠다.
+	// 1. spt에서 페이지 찾기
+	page = spt_find_page(spt,addr);
+	// 2. 페이지가 존재하지 않으면 segfault
+	if (page == NULL) {
+		return false;
+	}
+	// 3. SPT에 있지만 쓰기 보호인 경우
+	// TODO: not_prsent가 정확히 어떤 변수인지 -- PTE 테이블에 없다
+	// 단순 존재하지 않는다가 spt에서 존재하지 않는 것인지
+	if (write && !not_present && !page->writable) {
+		return vm_handle_wp(page);		// 구현 필요
+	}
 	return vm_do_claim_page (page);
 }
 
@@ -164,26 +225,40 @@ vm_dealloc_page (struct page *page) {
 	free (page);
 }
 
-/* Claim the page that allocate on VA. */
+/* VA에 할당된 페이지를 청구합니다. */
 bool
 vm_claim_page (void *va UNUSED) {
 	struct page *page = NULL;
-	/* TODO: Fill this function */
+	// spt에서 va에 해당하는 페이지 찾기
+	struct supplemental_page_table *spt = &thread_current ()->spt;
+	page = spt_find_page (spt, va);
+	if (page == NULL) {
+		return false;
+	}
 
 	return vm_do_claim_page (page);
 }
 
-/* Claim the PAGE and set up the mmu. */
+/* 페이지를 요청하고 mmu를 설정합니다. */
 static bool
 vm_do_claim_page (struct page *page) {
 	struct frame *frame = vm_get_frame ();
 
 	/* Set links */
-	frame->page = page;
+	frame->page = page;  
 	page->frame = frame;
 
-	/* TODO: Insert page table entry to map page's VA to frame's PA. */
-
+	/* TODO: 페이지의 VA를 프레임의 PA에 매핑하기 위해 페이지 테이블 항목을 삽입합니다. */
+	// Frame 테이블에 삽입 -> pml4에 매핑
+	struct thread *curr = thread_current();
+	// pml4에 매핑(= 메모리 할당 성공)
+	if(!pml4_set_page (curr->pml4, page->va, frame->kva, page->writable)){
+		return false;
+	}
+	// pml4_get_page (curr->pml4, page->va) == frame->kva
+	if(pml4_get_page (curr->pml4, page->va) == NULL){
+		return false;
+	}
 	return swap_in (page, frame->kva);
 }
 
@@ -191,7 +266,7 @@ vm_do_claim_page (struct page *page) {
 void
 supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
 	/* 해쉬 테이블 초기화 */
-	hash_init(spt->pages, spt_hash_func, spt_less_func, NULL);
+	hash_init(&spt->pages, spt_hash_func, spt_less_func, NULL);
 
 }
 
@@ -214,8 +289,7 @@ spt_hash_func (const struct hash_elem *hash_e, void *aux) {
 	struct page *page = hash_entry(hash_e, struct page, he);
 
 	/* hash 값 계산 */
-	void *va = page->va;
-	uint64_t hash = hash_bytes(va, sizeof(va));
+	uint64_t hash = hash_bytes(&page->va, sizeof(page->va));
 
 	return hash;
 }


### PR DESCRIPTION
## 요약
`developer` 브랜치를 `main`에 병합합니다.  
SPT 기본 기능 구현부터 lazy load, 페이지/프레임 관리, 스택 초기화까지 VM 전반의 핵심 기능이 포함된 업데이트입니다.

---

## 구현된 기능 / 변경 사항

### ✔ 주요 내용
- **SPT 기본 기능 구현 및 정리**
  - `hash_lookup` 제거 및 `spt_find_page`로 통합  
  - 반환값 및 예외 처리 개선  
  - `UNUSED` 추가

- **VM 주요 기능 구현**
  - `vm_alloc_page_with_initializer`  
  - `lazy_load_segment`  
  - `vm_try_handle_fault`  
  - `vm_get_frame`, `vm_claim_page`, `vm_do_claim_page`

- **스택 초기화 개선**
  - `setup_stack` 구현 및 페이지 초기화 로직 보완

- **버그 및 안정성 수정**
  - `hash_bytes` 인자 오류 수정  
  - `vm_claim_page`와 `spt_insert_page` 예외처리 정비

---

## 테스트 체크
- [x] 코드 빌드 성공 여부 
- [x] 추가된 기능에 대한 관련 테스트 케이스 통과 여부 
- [x] make check 실행 시 크래시 없이 동작 

---

## 논의했던 사항
- vm_try_handle_fault (write 처리): 쓰기 권한 없는 페이지에 대한 요청은 즉시 fault 발생
- vm_alloc_page_with_initializer: default case 반드시 추가
- page_fault (user 처리): 이번 PR에서는 제외
- 변수 선언 및 위치: fault context 계산은 vm_try_handle_fault 내에서 처리
- spt hash 방식: 포인터 없이 직접 hash 사용하기로 결정


