### PR TITLE
[feature] vm_stack_growth 기능 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -137,6 +137,7 @@ struct thread {
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
+	void *rsp;
 #endif
 
 	/* Owned by thread.c. */

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -105,6 +105,7 @@ validate_fd (int fd) {
 /* The main system call interface */
 void syscall_handler (struct intr_frame *f UNUSED) {
 	uint64_t rax = f->R.rax;
+	thread_current()->rsp = f->rsp; // vm에서 stack growth할 때 필요해서 현재 rsp저장
 
 	switch(rax) {
 		case SYS_WRITE : 


### PR DESCRIPTION
## 요약
스택 접근으로 발생한 page fault에 대해 스택을 동적으로 확장할 수 있도록 vm_stack_growth 기능을 구현하였습니다.

---

## 구현된 기능 / 변경 사항

### ✔ 주요 구현 내용
- thread 구조체에 `rsp` 필드를 추가하여 사용자 스택 포인터를 저장하도록 개선
- syscall_handler에서 유저 모드에게서 넘어온 `rsp` 값을 thread에 저장
- vm_stack_growth 함수 구현 (vm_alloc_page 기반으로 스택 페이지 동적 할당)
- vm_try_handle_fault에서 스택 확장 조건 판별 및 vm_stack_growth 호출 로직 추가

### ✔ 추가된 코드 또는 수정된 로직
- 관련 파일:
  - `threads/thread.h`
  - `userprog/syscall.c`
  - `vm/vm.c`
- thread 구조체 변경 및 thread 생성/복원 경로 수정
- 스택 확장 판단 로직 및 fault 처리 흐름 업데이트

### ✔ 상세 내용
- 사용자 스택 주소로 접근 시 페이지가 없으면 fault가 발생하는데, 기존에는 rsp 정보를 잃어 스택 확장 조건을 판별할 수 없었음  
- 이를 해결하기 위해 thread에 사용자 rsp를 저장하여 커널 모드 fault 상황에서도 올바른 스택 기준 주소를 판단할 수 있도록 구현  
- 정상적인 push/call 등의 스택 접근을 휴리스틱으로 감지해 스택 페이지를 할당하도록 구현  
- 스택 확장은 최대 크기 제한(1MB) 내부에서만 가능하도록 설계

---

## 테스트 결과

### ✔ PintOS 테스트 결과 체크
- [ ] 빌드 성공
- [ ] stack-growth 관련 테스트 케이스 통과
- [ ] make check 전체 테스트 크래시 없이 동작

---

## 남아 있는 TODO / 논의사항
- 스택 확장 범위(1MB 제한)에 대한 추가 검증 필요
- 스택 확장 조건 휴리스틱을 더 엄격하게 적용할 필요 여부 검토
- multi-page 확장 최적화 가능성

---

## 관련 이슈
- Close #28 
